### PR TITLE
LogicTimestamp 重启问题

### DIFF
--- a/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDelayDetector.java
+++ b/src/main/java/com/actiontech/dble/backend/heartbeat/MySQLDelayDetector.java
@@ -56,7 +56,7 @@ public class MySQLDelayDetector extends MySQLDetector {
             heartbeat.setSlaveBehindMaster((int) delayVal);
             heartbeat.setDbSynStatus(MySQLHeartbeat.DB_SYN_NORMAL);
         } else {
-            if (heartbeat.getStatus() != MySQLHeartbeat.OK_STATUS) {
+            if (logic == 0) {
                 long updatedLogic = dbGroup.getLogicTimestamp().updateAndGet(current -> Math.max(current, delay));
                 LOGGER.warn("delay detection rebased logic_timestamp to {} for dbGroup {}", updatedLogic, dbGroup.getGroupName());
                 heartbeat.setSlaveBehindMaster(0);


### PR DESCRIPTION
Reason:  
  Improve #. The current `logicTimestamp` rebase logic only applies when heartbeat status is not `OK`. This can lead to read instances being marked `DB_SYN_ERROR` and becoming unavailable if `logic - delay < 0` occurs when `logicTimestamp` is 0 (e.g., after restart) but the heartbeat status is already `OK`.
Type:  
  Improve  
Influences：  
  Allows `logicTimestamp` rebase when `logicTimestamp` is 0, ensuring correct initial synchronization after restarts.  
  Prevents read instances from being incorrectly marked `DB_SYN_ERROR` in such scenarios.  
  Enhances read instance availability and robustness after restarts.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5f2c651-bcfe-4c0c-a947-828449192825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5f2c651-bcfe-4c0c-a947-828449192825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts delay detection logic for read instances to ensure correct initial synchronization after restarts.
> 
> - When `logic - delay < 0` and `logicTimestamp` (`logic`) is `0`, rebase `logicTimestamp` to `delay`, set `slaveBehindMaster` to `0`, and mark `DB_SYN_NORMAL`
> - Removes dependency on heartbeat `OK` status for rebasing; keeps error state only when `logic > 0` and `logic - delay < 0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1170f04b099f3ce0234ea865dad45ed05dbd16dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->